### PR TITLE
Use shebangfix for python interpreter path

### DIFF
--- a/sysutils/ioc/Makefile
+++ b/sysutils/ioc/Makefile
@@ -14,7 +14,10 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}libioc>0:devel/py-libioc@${PY_FLAVOR} \
 				${PYTHON_PKGNAMEPREFIX}texttable>0:textproc/py-texttable@${PY_FLAVOR} \
 				${PYTHON_PKGNAMEPREFIX}click>0:devel/py-click@${PY_FLAVOR}
 
-USES=		python:3.6+
+USES=           python:3.6+ shebangfix
+
+SHEBANG_FILES=  bin/ioc
+python_OLD_CMD= /usr/local/bin/python3.6
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	bsdci


### PR DESCRIPTION
Use of the `shebangfix` tool mentioned by #1 